### PR TITLE
Initialize Django project scaffold with media handling

### DIFF
--- a/nutrition_bot/settings.py
+++ b/nutrition_bot/settings.py
@@ -10,6 +10,7 @@ For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
 
+import os
 from pathlib import Path
 
 # Build paths inside the project like this: BASE_DIR / 'subdir'.
@@ -117,6 +118,11 @@ USE_TZ = True
 
 STATIC_URL = "/static/"
 STATICFILES_DIRS = [BASE_DIR / "static"]
+STATIC_ROOT = BASE_DIR / "staticfiles"
+
+# Media files (User uploads)
+MEDIA_URL = "/media/"
+MEDIA_ROOT = BASE_DIR / "media"
 
 # Default primary key field type
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field

--- a/nutrition_bot/urls.py
+++ b/nutrition_bot/urls.py
@@ -15,9 +15,14 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 
+from django.conf import settings
+from django.conf.urls.static import static
 from django.contrib import admin
 from django.urls import path
 
 urlpatterns = [
     path("admin/", admin.site.urls),
 ]
+
+if settings.DEBUG:
+    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)


### PR DESCRIPTION
## Summary
- bootstrap a new Django 5 project rooted at the repository with manage.py and core configuration files
- configure settings for localized templates, static assets, SQLite database, and additional contrib utilities
- declare Python package requirements and add a gitignore for common Django artifacts
- configure static collection and media upload settings, including development serving of media assets

## Testing
- _Not run (Django not installed in container environment)_

------
https://chatgpt.com/codex/tasks/task_e_68e4ce1bd0a083208d682df5c0d3b3c6