### PR TITLE
Fix release-please workflow token configuration

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -14,7 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Run release-please
-        uses: google-github-actions/release-please-action@v4
+        uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}


### PR DESCRIPTION
## Summary
- switch release-please workflow to the maintained googleapis action
- allow supplying a personal access token via the RELEASE_PLEASE_TOKEN secret so the workflow can create pull requests when the GitHub Actions app is restricted

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68e55500392c8320ac09277d26c8343c