### PR TITLE
Document release PAT requirement

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,17 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
+      - name: Ensure PAT configured for release PRs
+        if: ${{ secrets.RELEASE_PLEASE_TOKEN == '' }}
+        run: |
+          echo "::error::The release workflow requires the RELEASE_PLEASE_TOKEN secret."
+          echo "::error::Create a fine-grained personal access token with \"contents: read\" and \"pull requests: write\" permissions and add it as the RELEASE_PLEASE_TOKEN repository secret."
+          exit 1
+
       - name: Run release-please
+        if: ${{ secrets.RELEASE_PLEASE_TOKEN != '' }}
         uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || github.token }}
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -57,6 +57,11 @@ pytest
 ۲. پس از merge در `main`، Release Please به صورت خودکار Pull Request نسخه بعدی و `CHANGELOG.md` را می‌سازد.
 ۳. با merge شدن PR انتشار، تگ `vMAJOR.MINOR.PATCH` ایجاد و Release در GitHub منتشر می‌شود.
 
+> **نکتهٔ مهم:** به دلیل محدودیت‌های مخزن، کاربر `github-actions[bot]` اجازهٔ ساخت Pull Request را ندارد. برای اجرای موفق
+> workflow انتشار، یک [Fine-grained Personal Access Token](https://github.com/settings/personal-access-tokens/new) با دسترسی‌های
+> **Contents (read)** و **Pull requests (write)** ایجاد کرده و آن را با نام `RELEASE_PLEASE_TOKEN` در Secrets مخزن قرار دهید.
+> در غیر این صورت job انتشار با پیام خطای راهنما متوقف می‌شود.
+
 ### ساخت و مصرف ایمیج Docker
 
 ایمیج‌ها در [GitHub Container Registry](https://ghcr.io) با نام `ghcr.io/OWNER/REPO` منتشر می‌شوند (جایگزین کردن `OWNER/REPO` با نام واقعی).


### PR DESCRIPTION
## Summary
- ensure the release workflow fails fast when the release PAT secret is missing
- document how to configure the RELEASE_PLEASE_TOKEN secret so release-please can open PRs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e5607293948320adb60e25d7e402a7